### PR TITLE
fix(requirements/common): Update version number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: python
 sudo: false
 python:
-- '3.6.5'
+  - '3.6.5'
 
 addons:
   postgresql: "9.5"
@@ -23,13 +23,13 @@ install:
   - pip install -r requirements/development.txt
 
 before_script:
-- export DATABASE_URL=postgres://postgres@localhost/nexus
-- psql -c "CREATE DATABASE nexus;" -U postgres
+  - export DATABASE_URL=postgres://postgres@localhost/nexus
+  - psql -c "CREATE DATABASE nexus;" -U postgres
 
 script:
-- flake8
-- pytest --cov -v --tb=native
-- ansible-playbook -i provisioner/hosts provisioner/site.yml --syntax-check
+  - flake8
+  - pytest --cov -v --tb=native
+  - ansible-playbook -i provisioner/hosts provisioner/site.yml --syntax-check
 
 notifications:
   email:

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -21,7 +21,7 @@ psycopg2-binary==2.7.6.1
 Pillow==5.0.0
 django-extensions==2.1.4
 django-uuid-upload-path==1.0.0
-django-versatileimagefield==1.9
+django-versatileimagefield==1.10
 django-extended-choices==1.3
 
 # REST APIs


### PR DESCRIPTION
Update django-versatileimagefield to version 1.10 from 1.9
Version 1.9 errors out(related to Pillow compilation from source) while using python 3.7